### PR TITLE
Allow aggregate functions to be applied to more types

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,9 +284,14 @@ const minSpec = {
   humanLabel: "minimum",
   HumanLabel: "Minimum",
   isSuitableType: isNumberLike,
-  sqlAggregateWrap: (sqlFrag) => sql.fragment`min(${sqlFrag})`,
+  sqlAggregateWrap: (sqlFrag, pgType) => sql.fragment`min(${sqlFrag})`,
 };
 ```
+
+Note that the attribute's pgType is passed to `sqlAggregateWrap` so the
+query fragment can be altered depending on the attribute. This is useful for
+making decisions about suitable default values, or to even use different
+aggregate functions for different types.
 
 See [src/AggregateSpecsPlugin.ts](src/AggregateSpecsPlugin.ts) for more
 details/examples.

--- a/src/AddAggregateTypesPlugin.ts
+++ b/src/AddAggregateTypesPlugin.ts
@@ -198,7 +198,10 @@ const AddAggregateTypesPlugin: Plugin = (builder) => {
                       const sqlColumn = sql.fragment`${queryBuilder.getTableAlias()}.${sql.identifier(
                         attr.name
                       )}`;
-                      const sqlAggregate = spec.sqlAggregateWrap(sqlColumn);
+                      const sqlAggregate = spec.sqlAggregateWrap(
+                        sqlColumn,
+                        attr.type
+                      );
                       queryBuilder.select(
                         sqlAggregate,
                         // We need a unique alias that we can later reference in the resolver

--- a/src/AddHavingAggregateTypesPlugin.ts
+++ b/src/AddHavingAggregateTypesPlugin.ts
@@ -301,7 +301,8 @@ const AddHavingAggregateTypesPlugin: Plugin = (builder) => {
                                   attr.name
                                 )}`;
                                 const aggregateExpression = aggregateSpec.sqlAggregateWrap(
-                                  columnExpression
+                                  columnExpression,
+                                  attr.type
                                 );
                                 return (
                                   HavingFilterType.extensions?.graphile?.toSql?.(
@@ -427,7 +428,8 @@ const AddHavingAggregateTypesPlugin: Plugin = (builder) => {
                                     { implicitArgs: [tableAlias] }
                                   );
                                   const aggregateExpression = aggregateSpec.sqlAggregateWrap(
-                                    functionCallExpression
+                                    functionCallExpression,
+                                    type
                                   );
                                   return HavingFilterType.extensions.graphile.toSql(
                                     val.filter,

--- a/src/AggregateSpecsPlugin.ts
+++ b/src/AggregateSpecsPlugin.ts
@@ -148,6 +148,10 @@ const AggregateSpecsPlugin: Plugin = (builder) => {
         // how the avg aggregate changes result type.
         pgTypeAndModifierModifier: convertWithMapAndFallback(
           {
+            [SMALLINT_OID]: NUMERIC_OID, // smallint -> numeric
+            [INTEGER_OID]: NUMERIC_OID, // integer -> numeric
+            [BIGINT_OID]: NUMERIC_OID, // bigint -> numeric
+            [NUMERIC_OID]: NUMERIC_OID, // numeric -> numeric
             [REAL_OID]: DOUBLE_PRECISION_OID, // real -> double precision
             [DOUBLE_PRECISION_OID]: DOUBLE_PRECISION_OID, // double precision -> double precision
             [INTERVAL_OID]: INTERVAL_OID, // interval -> interval

--- a/src/OrderByAggregatesPlugin.ts
+++ b/src/OrderByAggregatesPlugin.ts
@@ -143,7 +143,8 @@ const OrderByAggregatesPlugin: Plugin = (builder) => {
                   );
                 });
                 return sql.fragment`(select ${spec.sqlAggregateWrap(
-                  sql.fragment`${tableAlias}.${sql.identifier(attr.name)}`
+                  sql.fragment`${tableAlias}.${sql.identifier(attr.name)}`,
+                  attr.type
                 )} from ${sql.identifier(
                   table.namespaceName,
                   table.name

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -31,7 +31,7 @@ export interface AggregateSpec {
   shouldApplyToEntity?: (entity: PgAttribute | PgProc) => boolean;
 
   /** Wraps the SQL in an aggregate call */
-  sqlAggregateWrap: (sqlFrag: SQL) => SQL;
+  sqlAggregateWrap: (sqlFrag: SQL, pgType: PgType) => SQL;
 
   /**
    * Used to translate the PostgreSQL return type for the aggregate; for example:


### PR DESCRIPTION
## Description

The currently implemented aggregate functions are applicable to more types than are currently exposed. This expands the types that many of the aggregate functions can be applied to based upon this table in the Postgres docs: https://www.postgresql.org/docs/12/functions-aggregate.html

## Performance impact

None.

## Security impact

None.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [ ] ~~My code matches the project's code style and `yarn lint:fix` passes.~~ <sup>(Output is formatted with prettier, but `yarn lint:fix` is not yet available on this project.)</sup>
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~ <sup>(This project does not yet have a test suite.)</sup>
- [x] I have detailed the new feature in the relevant documentation.
- [ ] ~~I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).~~ <sup>(Doesn't yet exist.)</sup>
- [ ] ~~If this is a breaking change I've explained why.~~ <sup>(Not a breaking change.)</sup>

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
