### PR TITLE
feat: filter by aggregates in postgraphile-plugin-connection-filter

### DIFF
--- a/.postgraphilerc.js
+++ b/.postgraphilerc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  options: {
+    graphileBuildOptions: {
+      connectionFilterRelations: true, // default: false
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "watch": "tsc --watch",
     "test": "jest -i",
     "tslint": "prettier --list-different 'src/**/*' && tslint --config tslint.json --project tsconfig.json",
-    "postgraphile": "nodemon --watch dist -x 'node --inspect ../build/postgraphile/cli.js --append-plugins `pwd`/dist/index.js -c graphile_aggregates -s test --enhance-graphiql --allow-explain --watch --dynamic-json --show-error-stack --extended-errors severity,code,detail,hint,position,internalPosition,internalQuery,where,schema,table,column,dataType,constraint,file,line,routine'",
+    "postgraphile": "nodemon --watch dist -x './postgraphile.sh'",
     "dev": "psql -X1v ON_ERROR_STOP=1 -f __tests__/schema.sql graphile_aggregates && concurrently --kill-others 'npm run watch' 'npm run postgraphile'",
     "prepack": "rm -Rf dist && npm run build"
   },
@@ -45,6 +45,7 @@
     "nodemon": "^2.0.7",
     "pg": "^8.5.1",
     "postgraphile": "^4.12.0-alpha.0",
+    "postgraphile-plugin-connection-filter": "^2.2.0",
     "prettier": "^2.2.1",
     "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.18.0",
@@ -56,7 +57,5 @@
     "debug": "^4.3.1",
     "graphile-utils": "^4.12.0-alpha.0"
   },
-  "files": [
-    "dist"
-  ]
+  "files": ["dist"]
 }

--- a/postgraphile.sh
+++ b/postgraphile.sh
@@ -9,5 +9,5 @@ node \
   --allow-explain \
   --watch \
   --dynamic-json \
-  --show-error-stack \
+  --show-error-stack=json \
   --extended-errors severity,code,detail,hint,position,internalPosition,internalQuery,where,schema,table,column,dataType,constraint,file,line,routine

--- a/postgraphile.sh
+++ b/postgraphile.sh
@@ -1,0 +1,13 @@
+node \
+  --inspect \
+  ../build/postgraphile/cli.js \
+  --append-plugins \
+    `pwd`/node_modules/postgraphile-plugin-connection-filter,`pwd`/dist/index.js \
+  -c graphile_aggregates \
+  -s test \
+  --enhance-graphiql \
+  --allow-explain \
+  --watch \
+  --dynamic-json \
+  --show-error-stack \
+  --extended-errors severity,code,detail,hint,position,internalPosition,internalQuery,where,schema,table,column,dataType,constraint,file,line,routine

--- a/src/FilterRelationalAggregatesPlugin.ts
+++ b/src/FilterRelationalAggregatesPlugin.ts
@@ -1,0 +1,148 @@
+import type { Plugin } from "graphile-build";
+import type { ConnectionFilterResolver } from "postgraphile-plugin-connection-filter/dist/PgConnectionArgFilterPlugin";
+import type { BackwardRelationSpec } from "postgraphile-plugin-connection-filter/dist/PgConnectionArgFilterBackwardRelationsPlugin";
+
+const FilterRelationalAggregatesPlugin: Plugin = (builder) => {
+  // See https://github.com/graphile-contrib/postgraphile-plugin-connection-filter/blob/6223cdb1d2ac5723aecdf55f735a18f8e2b98683/src/PgConnectionArgFilterBackwardRelationsPlugin.ts#L374
+  builder.hook("GraphQLInputObjectType:fields", (fields, build, context) => {
+    const {
+      extend,
+      newWithHooks,
+      inflection,
+      pgSql: sql,
+      connectionFilterResolve,
+      connectionFilterRegisterResolver,
+      connectionFilterTypesByTypeName,
+      connectionFilterType,
+      graphql,
+    } = build;
+    const {
+      fieldWithHooks,
+      scope: { foreignTable, isPgConnectionFilterMany },
+      Self,
+    } = context;
+
+    if (!isPgConnectionFilterMany || !foreignTable) return fields;
+
+    connectionFilterTypesByTypeName[Self.name] = Self;
+
+    const foreignTableTypeName = inflection.tableType(foreignTable);
+    const foreignTableFilterTypeName = inflection.filterType(
+      foreignTableTypeName
+    );
+    const foreignTableAggregateFilterTypeName = inflection.filterType(
+      foreignTableTypeName + "Aggregates"
+    );
+
+    const FilterType = connectionFilterType(
+      newWithHooks,
+      foreignTableFilterTypeName,
+      foreignTable,
+      foreignTableTypeName
+    );
+
+    const AggregateType = (() => {
+      if (
+        !(
+          foreignTableAggregateFilterTypeName in connectionFilterTypesByTypeName
+        )
+      ) {
+        connectionFilterTypesByTypeName[
+          foreignTableAggregateFilterTypeName
+        ] = newWithHooks(
+          graphql.GraphQLInputObjectType,
+          {
+            description: `A filter to be used against aggregates of \`${foreignTableTypeName}\` object types.`,
+            name: foreignTableAggregateFilterTypeName,
+            fields: {
+              filter: {
+                description: `A filter that must pass for the relevant \`${foreignTableTypeName}\` object to be included within the aggregate.`,
+                type: FilterType,
+              },
+            },
+          },
+          {
+            pgIntrospection: foreignTable,
+            isPgConnectionAggregateFilter: true,
+          },
+          true
+        );
+      }
+      return connectionFilterTypesByTypeName[
+        foreignTableAggregateFilterTypeName
+      ];
+    })();
+
+    if (!AggregateType) {
+      return fields;
+    }
+
+    const resolve: ConnectionFilterResolver = ({
+      sourceAlias,
+      // fieldName,
+      fieldValue,
+      queryBuilder,
+      parentFieldInfo,
+    }) => {
+      if (fieldValue == null) return null;
+
+      if (!parentFieldInfo || !parentFieldInfo.backwardRelationSpec) {
+        throw new Error("Did not receive backward relation spec");
+      }
+      const {
+        keyAttributes,
+        foreignKeyAttributes,
+      }: BackwardRelationSpec = parentFieldInfo.backwardRelationSpec;
+
+      const foreignTableAlias = sql.identifier(Symbol());
+      const sqlIdentifier = sql.identifier(
+        foreignTable.namespace.name,
+        foreignTable.name
+      );
+      const sqlKeysMatch = sql.query`(${sql.join(
+        foreignKeyAttributes.map((attr, i) => {
+          return sql.fragment`${foreignTableAlias}.${sql.identifier(
+            attr.name
+          )} = ${sourceAlias}.${sql.identifier(keyAttributes[i].name)}`;
+        }),
+        ") and ("
+      )})`;
+
+      const sqlFragment = connectionFilterResolve(
+        (fieldValue as any).filter,
+        foreignTableAlias,
+        foreignTableFilterTypeName,
+        queryBuilder
+      );
+      const sqlConditions = [sql.fragment`sum(saves) > 9`];
+      const sqlSelectWhereKeysMatch = sql.query`(select (${sql.join(
+        sqlConditions,
+        ") and ("
+      )}) from (
+          select * from ${sqlIdentifier} as ${foreignTableAlias}
+          where ${sqlKeysMatch}
+          and (${sqlFragment})
+        ) as ${foreignTableAlias}
+      )`;
+      return sqlSelectWhereKeysMatch;
+    };
+
+    const aggregatesFieldName = "aggregates";
+    connectionFilterRegisterResolver(Self.name, aggregatesFieldName, resolve);
+
+    return extend(fields, {
+      [aggregatesFieldName]: fieldWithHooks(
+        aggregatesFieldName,
+        {
+          description: `Aggregates across related \`${foreignTableTypeName}\` match the filter criteria.`,
+          type: AggregateType,
+        },
+        {
+          isPgConnectionFilterAggregatesField: true,
+        }
+      ),
+    });
+  });
+};
+
+export default FilterRelationalAggregatesPlugin;

--- a/src/FilterRelationalAggregatesPlugin.ts
+++ b/src/FilterRelationalAggregatesPlugin.ts
@@ -165,7 +165,6 @@ const FilterRelationalAggregatesPlugin: Plugin = (builder) => {
       graphql,
       newWithHooks,
       inflection,
-      pgSql: sql,
       connectionFilterResolve,
       connectionFilterRegisterResolver,
     } = build;
@@ -222,7 +221,6 @@ const FilterRelationalAggregatesPlugin: Plugin = (builder) => {
           filterTypeName,
           queryBuilder
         );
-        console.log(sql.compile(sqlFrag));
         return sqlFrag;
       };
       connectionFilterRegisterResolver(Self.name, fieldName, resolve);
@@ -318,7 +316,6 @@ const FilterRelationalAggregatesPlugin: Plugin = (builder) => {
             pgTypeModifier,
             fieldName
           );
-          console.dir(frag);
           return frag;
         };
         connectionFilterRegisterResolver(Self.name, fieldName, resolve);
@@ -389,7 +386,6 @@ const FilterRelationalAggregatesPlugin: Plugin = (builder) => {
             null,
             fieldName
           );
-          console.dir(frag);
           return frag;
         };
         connectionFilterRegisterResolver(Self.name, fieldName, resolve);

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import AddAggregateTypesPlugin from "./AddAggregateTypesPlugin";
 import AddConnectionAggregatesPlugin from "./AddConnectionAggregatesPlugin";
 import AddConnectionGroupedAggregatesPlugin from "./AddConnectionGroupedAggregatesPlugin";
 import OrderByAggregatesPlugin from "./OrderByAggregatesPlugin";
+import FilterRelationalAggregatesPlugin from "./FilterRelationalAggregatesPlugin";
 
 export default makePluginByCombiningPlugins(
   InflectionPlugin,
@@ -18,5 +19,6 @@ export default makePluginByCombiningPlugins(
   AddAggregateTypesPlugin,
   AddConnectionAggregatesPlugin,
   AddConnectionGroupedAggregatesPlugin,
-  OrderByAggregatesPlugin
+  OrderByAggregatesPlugin,
+  FilterRelationalAggregatesPlugin
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1337,6 +1337,11 @@ postgraphile-core@4.12.0-alpha.0:
     graphile-build-pg "4.12.0-alpha.0"
     tslib "^2.0.1"
 
+postgraphile-plugin-connection-filter@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/postgraphile-plugin-connection-filter/-/postgraphile-plugin-connection-filter-2.2.0.tgz#2ce3cc4550114f6e89ef4cf6ce27a268964f170e"
+  integrity sha512-l7bliND34gv3pkBUxCtBx059M7sJH2hRZ3J95JewJkNJN7EibknDcG8sO14kJ+PHnCtXUBh+WxbX/jz9huTu6Q==
+
 postgraphile@^4.12.0-alpha.0:
   version "4.12.0-alpha.0"
   resolved "https://registry.yarnpkg.com/postgraphile/-/postgraphile-4.12.0-alpha.0.tgz#54be69de2b9471854befce66757a14ddb515c2f9"


### PR DESCRIPTION
## Description

Extends `@graphile/pg-aggregates` to add filtering capabilities on aggregates; for example:

```graphql
query PlayersWith9OrMoreSavesInMatchesTheyScoredIn {
  allPlayers(
    filter: {
      matchStatsByPlayerId: {
        aggregates: {
          sum: { saves: { greaterThan: "9" }, rating: { lessThan: 143 } }
          filter: { goals: { greaterThan: 0 } }
        }
      }
    }
  ) {
    nodes {
      name
    }
  }
}
```

This finds the names of players who, in matches in which they scored at least 1 goal, achieved at least 10 saves but a total per-game rating (summed across the filtered matches) of less than 143.

## Performance impact

Aggregates are expensive. Filtering by aggregates is even more expensive. Using this plugin is expensive. Use at your own risk.

## Security impact

The expected performance and potential denial of service issues inherent in allowing end users to construct arbitrary aggregate expressions against your API.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

