### PR TITLE
WIP - Add Typical Charting Truncations 

### DIFF
--- a/src/AggregateSpecsPlugin.ts
+++ b/src/AggregateSpecsPlugin.ts
@@ -190,20 +190,79 @@ const AggregateSpecsPlugin: Plugin = (builder) => {
     ];
 
     const pgAggregateGroupBySpecs: AggregateGroupBySpec[] = [
-      {
-        id: "truncated-to-hour",
+     {
+        id: "truncated-to-millennium",
         isSuitableType: (pgType) =>
-          /* timestamp or timestamptz */
           pgType.id === TIMESTAMP_OID || pgType.id === TIMESTAMPTZ_OID,
-        sqlWrap: (sqlFrag) => sql.fragment`date_trunc('hour', ${sqlFrag})`,
+        sqlWrap: (sqlFrag) => sql.fragment`date_trunc('millennium', ${sqlFrag})`,
+      },
+      {
+        id: "truncated-to-century",
+        isSuitableType: (pgType) =>
+          pgType.id === TIMESTAMP_OID || pgType.id === TIMESTAMPTZ_OID,
+        sqlWrap: (sqlFrag) => sql.fragment`date_trunc('century', ${sqlFrag})`,
+      },
+      {
+        id: "truncated-to-decade",
+        isSuitableType: (pgType) =>
+          pgType.id === TIMESTAMP_OID || pgType.id === TIMESTAMPTZ_OID,
+        sqlWrap: (sqlFrag) => sql.fragment`date_trunc('decade', ${sqlFrag})`,
+      },
+      {
+        id: "truncated-to-year",
+        isSuitableType: (pgType) =>
+          pgType.id === TIMESTAMP_OID || pgType.id === TIMESTAMPTZ_OID,
+        sqlWrap: (sqlFrag) => sql.fragment`date_trunc('year', ${sqlFrag})`,
+      },
+      {
+        id: "truncated-to-month",
+        isSuitableType: (pgType) =>
+          pgType.id === TIMESTAMP_OID || pgType.id === TIMESTAMPTZ_OID,
+        sqlWrap: (sqlFrag) => sql.fragment`date_trunc('month', ${sqlFrag})`,
+      },
+      {
+        id: "truncated-to-week",
+        isSuitableType: (pgType) =>
+          pgType.id === TIMESTAMP_OID || pgType.id === TIMESTAMPTZ_OID,
+        sqlWrap: (sqlFrag) => sql.fragment`date_trunc('week', ${sqlFrag})`,
       },
       {
         id: "truncated-to-day",
         isSuitableType: (pgType) =>
-          /* timestamp or timestamptz */
           pgType.id === TIMESTAMP_OID || pgType.id === TIMESTAMPTZ_OID,
         sqlWrap: (sqlFrag) => sql.fragment`date_trunc('day', ${sqlFrag})`,
       },
+      // WARNING: grouping by hour or less can easily create high cost queries, returning many rows
+      {
+        id: "truncated-to-hour",
+        isSuitableType: (pgType) =>
+          pgType.id === TIMESTAMP_OID || pgType.id === TIMESTAMPTZ_OID,
+        sqlWrap: (sqlFrag) => sql.fragment`date_trunc('hour', ${sqlFrag})`,
+      },
+      {
+        id: "truncated-to-minute",
+        isSuitableType: (pgType) =>
+          pgType.id === TIMESTAMP_OID || pgType.id === TIMESTAMPTZ_OID,
+        sqlWrap: (sqlFrag) => sql.fragment`date_trunc('minute', ${sqlFrag})`,
+      },
+      {
+        id: "truncated-to-second",
+        isSuitableType: (pgType) =>
+          pgType.id === TIMESTAMP_OID || pgType.id === TIMESTAMPTZ_OID,
+        sqlWrap: (sqlFrag) => sql.fragment`date_trunc('second', ${sqlFrag})`,
+      },
+      {
+        id: "truncated-to-milliseconds",
+        isSuitableType: (pgType) =>
+          pgType.id === TIMESTAMP_OID || pgType.id === TIMESTAMPTZ_OID,
+        sqlWrap: (sqlFrag) => sql.fragment`date_trunc('milliseconds', ${sqlFrag})`,
+      },
+      {
+        id: "truncated-to-microseconds",
+        isSuitableType: (pgType) =>
+          pgType.id === TIMESTAMP_OID || pgType.id === TIMESTAMPTZ_OID,
+        sqlWrap: (sqlFrag) => sql.fragment`date_trunc('microseconds', ${sqlFrag})`,
+      }
     ];
 
     return build.extend(build, {

--- a/src/AggregateSpecsPlugin.ts
+++ b/src/AggregateSpecsPlugin.ts
@@ -197,6 +197,12 @@ const AggregateSpecsPlugin: Plugin = (builder) => {
         sqlWrap: (sqlFrag) => sql.fragment`date_trunc('year', ${sqlFrag})`,
       },
       {
+        id: "truncated-to-quarter",
+        isSuitableType: (pgType) =>
+          pgType.id === TIMESTAMP_OID || pgType.id === TIMESTAMPTZ_OID,
+        sqlWrap: (sqlFrag) => sql.fragment`date_trunc('quarter', ${sqlFrag})`,
+      },
+      {
         id: "truncated-to-month",
         isSuitableType: (pgType) =>
           pgType.id === TIMESTAMP_OID || pgType.id === TIMESTAMPTZ_OID,

--- a/src/AggregateSpecsPlugin.ts
+++ b/src/AggregateSpecsPlugin.ts
@@ -190,24 +190,6 @@ const AggregateSpecsPlugin: Plugin = (builder) => {
     ];
 
     const pgAggregateGroupBySpecs: AggregateGroupBySpec[] = [
-     {
-        id: "truncated-to-millennium",
-        isSuitableType: (pgType) =>
-          pgType.id === TIMESTAMP_OID || pgType.id === TIMESTAMPTZ_OID,
-        sqlWrap: (sqlFrag) => sql.fragment`date_trunc('millennium', ${sqlFrag})`,
-      },
-      {
-        id: "truncated-to-century",
-        isSuitableType: (pgType) =>
-          pgType.id === TIMESTAMP_OID || pgType.id === TIMESTAMPTZ_OID,
-        sqlWrap: (sqlFrag) => sql.fragment`date_trunc('century', ${sqlFrag})`,
-      },
-      {
-        id: "truncated-to-decade",
-        isSuitableType: (pgType) =>
-          pgType.id === TIMESTAMP_OID || pgType.id === TIMESTAMPTZ_OID,
-        sqlWrap: (sqlFrag) => sql.fragment`date_trunc('decade', ${sqlFrag})`,
-      },
       {
         id: "truncated-to-year",
         isSuitableType: (pgType) =>
@@ -239,30 +221,6 @@ const AggregateSpecsPlugin: Plugin = (builder) => {
           pgType.id === TIMESTAMP_OID || pgType.id === TIMESTAMPTZ_OID,
         sqlWrap: (sqlFrag) => sql.fragment`date_trunc('hour', ${sqlFrag})`,
       },
-      {
-        id: "truncated-to-minute",
-        isSuitableType: (pgType) =>
-          pgType.id === TIMESTAMP_OID || pgType.id === TIMESTAMPTZ_OID,
-        sqlWrap: (sqlFrag) => sql.fragment`date_trunc('minute', ${sqlFrag})`,
-      },
-      {
-        id: "truncated-to-second",
-        isSuitableType: (pgType) =>
-          pgType.id === TIMESTAMP_OID || pgType.id === TIMESTAMPTZ_OID,
-        sqlWrap: (sqlFrag) => sql.fragment`date_trunc('second', ${sqlFrag})`,
-      },
-      {
-        id: "truncated-to-milliseconds",
-        isSuitableType: (pgType) =>
-          pgType.id === TIMESTAMP_OID || pgType.id === TIMESTAMPTZ_OID,
-        sqlWrap: (sqlFrag) => sql.fragment`date_trunc('milliseconds', ${sqlFrag})`,
-      },
-      {
-        id: "truncated-to-microseconds",
-        isSuitableType: (pgType) =>
-          pgType.id === TIMESTAMP_OID || pgType.id === TIMESTAMPTZ_OID,
-        sqlWrap: (sqlFrag) => sql.fragment`date_trunc('microseconds', ${sqlFrag})`,
-      }
     ];
 
     return build.extend(build, {


### PR DESCRIPTION
## Description

Hour & Day are nice, but groups by Year, Quarter, Month & Week have common reporting and charting uses. This plugin is meant to extend the core into a tool for reporting and charting it even includes standard deviation calculations.

See https://github.com/graphile/pg-aggregates/issues/20 for more. 

TLDR: writing a plugin to extend this plugin using JS fails when combining with the having clauses. 

I'll be keeping this fork up to date and relying on it until/unless this is merged or I find a way to hook into another **appendPlugin** properly.

## Performance impact

Zero performance impact, only adding lower cost aggregations.

## Security impact

Zero security impact, only adding more options to an existing enum. The existing risk from the attack vector of "hour" being included, is greater than anything I've added here. I even considered removing it, but instead left a comment to point out the not-so-obvious security/cost hole of having it included by default.

## Checklist

- [ ] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.
