### PR TITLE
this adds orderBy for computed columns

### DIFF
--- a/src/InflectionPlugin.ts
+++ b/src/InflectionPlugin.ts
@@ -108,4 +108,22 @@ export default makeAddInflectorsPlugin({
       `${relationName}-${aggregateSpec.id}-${this._columnName(column)}`
     );
   },
+  orderByProcAggregateOfManyRelationByKeys(
+    detailedKeys: Keys,
+    table: PgClass,
+    foreignTable: PgClass,
+    constraint: PgConstraint,
+    aggregateSpec: AggregateSpec,
+    name: string
+  ) {
+    const relationName = this.manyRelationByKeys(
+      detailedKeys,
+      table,
+      foreignTable,
+      constraint
+    );
+    return this.constantCase(
+      `${relationName}-${aggregateSpec.id}-${name}`
+    );
+  },
 });


### PR DESCRIPTION
## Description

i dont know nearly enough about the query builder or the build hooks to know if this is okay. this worked for what I needed, so i figured i would PR to see if it's helpful at all. 

(with the demo sql) allows: 

```
query FocussedOrderedAggregate {
  allPlayers(
    first: 5
    orderBy: [MATCH_STATS_BY_PLAYER_ID_AVERAGE_RATING_DESC]
  ) {
    nodes {
      ...
    }
  }
}
```

## Performance impact

unknown

## Security impact

unknown
