### PR TITLE
Disable aggregates

### DIFF
--- a/.postgraphilerc.js
+++ b/.postgraphilerc.js
@@ -2,6 +2,7 @@ module.exports = {
   options: {
     graphileBuildOptions: {
       connectionFilterRelations: true, // default: false
+      disableAggregatesByDefault: false, // default: false
     },
   },
 };

--- a/README.md
+++ b/README.md
@@ -426,6 +426,50 @@ Finally pass this plugin into PostGraphile via `--append-plugins` or
 See [src/AggregateSpecsPlugin.ts](src/AggregateSpecsPlugin.ts) for examples and
 more information.
 
+## Disable aggregates
+
+The aggregates are created for all tables which really massively increases the type def in size.
+You can disable aggregates by default and enable them only for the tables yo need.
+
+```ts
+// Disable aggregates by default
+graphileBuildOptions: {
+  disableAggregatesByDefault: true,
+}
+```
+
+Enable aggregates for a specific table:
+
+```ts
+"my_schema.my_table": {
+  "tags": {
+    "aggregates": "on"
+  }
+}
+```
+
+OR
+
+```sql
+COMMENT ON TABLE my_schema.my_table IS E'@aggregates on';
+```
+
+You also can keep aggregates enabled by default, but disable aggregates for specific tables:
+
+```ts
+"my_schema.my_table": {
+  "tags": {
+    "aggregates": "off"
+  }
+}
+```
+
+OR
+
+```sql
+COMMENT ON TABLE my_schema.my_table IS E'@aggregates off';
+```
+
 ## Thanks
 
 This plugin was started as a proof of concept in 2019 thanks to sponsorship from

--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ more information.
 ## Disable aggregates
 
 The aggregates are created for all tables which really massively increases the type def in size.
-You can disable aggregates by default and enable them only for the tables yo need.
+You can disable aggregates by default and enable them only for the tables you need.
 
 ```ts
 // Disable aggregates by default
@@ -448,7 +448,7 @@ Enable aggregates for a specific table:
 }
 ```
 
-OR
+or:
 
 ```sql
 COMMENT ON TABLE my_schema.my_table IS E'@aggregates on';
@@ -464,7 +464,7 @@ You also can keep aggregates enabled by default, but disable aggregates for spec
 }
 ```
 
-OR
+or:
 
 ```sql
 COMMENT ON TABLE my_schema.my_table IS E'@aggregates off';

--- a/src/AddAggregateTypesPlugin.ts
+++ b/src/AddAggregateTypesPlugin.ts
@@ -8,7 +8,7 @@ import type {
 import type { GraphQLResolveInfo, GraphQLFieldConfigMap } from "graphql";
 import { AggregateSpec } from "./interfaces";
 
-const AddAggregateTypesPlugin: Plugin = (builder) => {
+const AddAggregateTypesPlugin: Plugin = (builder, options) => {
   // Create the aggregates type for each table
   builder.hook("init", (init, build, _context) => {
     const {
@@ -35,6 +35,12 @@ const AddAggregateTypesPlugin: Plugin = (builder) => {
         return;
       }
       if (!table.isSelectable) {
+        return;
+      }
+      if (table.tags.aggregates === "off") {
+        return;
+      }
+      if (options.disableAggregatesByDefault && table.tags.aggregates !== "on") {
         return;
       }
 


### PR DESCRIPTION
## Description

The aggregates are created for all tables which really massively increases the type def in size.
This PR adds ability to disable aggregates by default and enable/disable aggregates for specific tables.

## Performance impact

Unknown

## Security impact

Unknown

## Checklist

- [ ] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.
