### PR TITLE
Option to disable aggregates by default and for specific tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ You also can keep aggregates enabled by default, but disable aggregates for spec
 COMMENT ON TABLE my_schema.my_table IS E'@behavior -aggregates';
 ```
 
-You can continue to use your `postgraphile.tags.json5` file, if you used it for postgraphile V4
+You can continue to use your `postgraphile.tags.json5` file if you used it for postgraphile V4
 
  - to enable aggregates for a specific table
 ```json
@@ -479,6 +479,8 @@ You can continue to use your `postgraphile.tags.json5` file, if you used it for 
   }
 }
 ```
+
+You can continue to use yor `@aggregates` smart tags if you already have them - it isn't necessary to replace them to behaviors.
 
 ## Thanks
 

--- a/README.md
+++ b/README.md
@@ -426,6 +426,60 @@ Finally pass this plugin into PostGraphile via `--append-plugins` or
 See [src/AggregateSpecsPlugin.ts](src/AggregateSpecsPlugin.ts) for examples and
 more information.
 
+## Disable aggregates
+
+By default, aggregates are created for all tables. This significantly increases the size of your
+GraphQL schema, and could also be a security (DoS) concern as aggregates can be expensive. We
+recommend that you use the `-aggregates` default behavior to disable aggregates by
+default, and then enable them only for the tables you need:
+
+```ts
+// graphile.config.mjs
+
+export default {
+  // ...
+  schema: {
+    defaultBehavior: "-aggregates",
+  },
+};
+```
+
+Enable aggregates for a specific table:
+
+```sql
+COMMENT ON TABLE my_schema.my_table IS E'@behavior +aggregates';
+```
+
+You also can keep aggregates enabled by default, but disable aggregates for specific tables:
+
+```sql
+COMMENT ON TABLE my_schema.my_table IS E'@behavior -aggregates';
+```
+
+You can continue to use your `postgraphile.tags.json5` file, if you used it for postgraphile V4
+
+ - to enable aggregates for a specific table
+```json
+"class": {
+  "my_schema.my_table": {
+    "tags": {
+      "aggregates": "on"
+    }
+  }
+}
+```
+
+ - to disable aggregates for a specific table
+```json
+"class": {
+  "my_schema.my_table": {
+    "tags": {
+      "aggregates": "off"
+    }
+  }
+}
+```
+
 ## Thanks
 
 This plugin was started as a proof of concept in 2019 thanks to sponsorship from

--- a/src/AddAggregateTypesPlugin.ts
+++ b/src/AddAggregateTypesPlugin.ts
@@ -26,7 +26,7 @@ const isSuitableSource = (
     return false;
   }
 
-  return true;
+  return !!build.behavior.pgResourceMatches(resource, "aggregates");
 };
 const Plugin: GraphileConfig.Plugin = {
   name: "PgAggregatesAddAggregateTypesPlugin",

--- a/src/AggregatesSmartTagsPlugin.ts
+++ b/src/AggregatesSmartTagsPlugin.ts
@@ -1,0 +1,62 @@
+import "graphile-config";
+
+import { gatherConfig } from "graphile-build";
+import { addBehaviorToTags } from "graphile-build-pg";
+
+// @ts-ignore
+const { version } = require("../package.json");
+
+declare global {
+  namespace GraphileConfig {
+    interface GatherHelpers {
+      pgV4AggregatesSmartTags: Record<string, never>;
+    }
+  }
+}
+
+const EMPTY_OBJECT = Object.freeze({});
+
+export const PgAggregatesSmartTagsPlugin: GraphileConfig.Plugin = {
+  name: "PgAggregatesSmartTagsPlugin",
+  description:
+    "For compatibility with PostGraphile v4 schemas, this plugin attempts to convert `@aggregates` V4 smart tags to V5 behaviors",
+  version,
+  before: [
+    "PgAggregatesAddAggregateTypesPlugin",
+    "PgAggregatesFilterRelationalAggregatesPlugin",
+    "PgAggregatesOrderByAggregatesPlugin",
+  ],
+  provides: ["smart-tags"],
+
+  gather: gatherConfig({
+    namespace: "pgV4AggregatesSmartTags",
+    initialCache() {
+      return EMPTY_OBJECT;
+    },
+    initialState() {
+      return EMPTY_OBJECT;
+    },
+    helpers: {},
+    hooks: {
+      // Run in the 'introspection' phase before anything uses the tags
+      pgIntrospection_introspection(info, event) {
+        for (const pgClass of event.introspection.classes) {
+          processTags(pgClass.getTags());
+        }
+      },
+    },
+  }),
+};
+
+function processTags(
+  tags: Partial<GraphileBuild.PgSmartTagsDict> | undefined,
+): void {
+  switch (tags?.aggregates) {
+    case "on":
+      addBehaviorToTags(tags, "+aggregates");
+      break;
+    case "off":
+      addBehaviorToTags(tags, "-aggregates");
+      break;
+  }
+}

--- a/src/FilterRelationalAggregatesPlugin.ts
+++ b/src/FilterRelationalAggregatesPlugin.ts
@@ -13,6 +13,7 @@ import type {
 } from "grafast";
 import type { GraphQLInputObjectType } from "graphql";
 import type { PgSQL, SQL } from "pg-sql2";
+import type {} from "graphile-build";
 import type {} from "postgraphile-plugin-connection-filter";
 
 import type { AggregateSpec } from "./interfaces.js";
@@ -229,7 +230,9 @@ group by true)`;
           if (foreignTable.parameters || !foreignTable.codec.attributes) {
             continue;
           }
-          // TODO: if behavior includes filter:aggregates
+          if (!build.behavior.pgResourceMatches(foreignTable, "aggregates")) {
+            continue;
+          }
 
           const foreignTableTypeName = inflection.tableType(foreignTable.codec);
           const foreignTableFilterTypeName =

--- a/src/OrderByAggregatesPlugin.ts
+++ b/src/OrderByAggregatesPlugin.ts
@@ -61,6 +61,11 @@ export const PgAggregatesOrderByAggregatesPlugin: GraphileConfig.Plugin = {
             if (!build.behavior.pgCodecRelationMatches(relation, "select")) {
               return memo;
             }
+            if (
+              !build.behavior.pgCodecRelationMatches(relation, "aggregates")
+            ) {
+              return memo;
+            }
             const table = relation.remoteResource as PgResource;
             const isUnique = !!relation.isUnique;
             if (isUnique) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { PgAggregatesAddGroupByAggregateEnumsPlugin } from "./AddGroupByAggregat
 import { PgAggregatesAddGroupByAggregateEnumValuesForAttributesPlugin } from "./AddGroupByAggregateEnumValuesForAttributesPlugin.js";
 import { PgAggregatesAddHavingAggregateTypesPlugin } from "./AddHavingAggregateTypesPlugin.js";
 import { PgAggregatesSpecsPlugin } from "./AggregateSpecsPlugin.js";
+import { PgAggregatesSmartTagsPlugin } from "./AggregatesSmartTagsPlugin.js";
 import { PgAggregatesFilterRelationalAggregatesPlugin } from "./FilterRelationalAggregatesPlugin.js";
 import { PgAggregatesInflectorsPlugin } from "./InflectionPlugin.js";
 import { PgAggregatesOrderByAggregatesPlugin } from "./OrderByAggregatesPlugin.js";
@@ -12,6 +13,7 @@ import { PgAggregatesOrderByAggregatesPlugin } from "./OrderByAggregatesPlugin.j
 export const PgAggregatesPreset: GraphileConfig.Preset = {
   plugins: [
     PgAggregatesInflectorsPlugin,
+    PgAggregatesSmartTagsPlugin,
     PgAggregatesSpecsPlugin,
     PgAggregatesAddGroupByAggregateEnumsPlugin,
     PgAggregatesAddGroupByAggregateEnumValuesForAttributesPlugin,
@@ -22,6 +24,10 @@ export const PgAggregatesPreset: GraphileConfig.Preset = {
     PgAggregatesOrderByAggregatesPlugin,
     PgAggregatesFilterRelationalAggregatesPlugin,
   ],
+
+  schema: {
+    defaultBehavior: "+aggregates",
+  },
 };
 
-// :args src/InflectionPlugin.ts src/AggregateSpecsPlugin.ts src/AddGroupByAggregateEnumsPlugin.ts src/AddGroupByAggregateEnumValuesForAttributesPlugin.ts src/AddHavingAggregateTypesPlugin.ts src/AddAggregateTypesPlugin.ts src/AddConnectionAggregatesPlugin.ts src/AddConnectionGroupedAggregatesPlugin.ts src/OrderByAggregatesPlugin.ts src/FilterRelationalAggregatesPlugin.ts
+// :args src/InflectionPlugin.ts src/AggregateSpecsPlugin.ts src/AddGroupByAggregateEnumsPlugin.ts src/AddGroupByAggregateEnumValuesForAttributesPlugin.ts src/AddHavingAggregateTypesPlugin.ts src/AddAggregateTypesPlugin.ts src/AddConnectionAggregatesPlugin.ts src/AddConnectionGroupedAggregatesPlugin.ts src/OrderByAggregatesPlugin.ts src/FilterRelationalAggregatesPlugin.ts src/AggregatesSmartTagsPlugin.ts


### PR DESCRIPTION
## Description

The aggregates are created for all tables which really massively increases the type def in size.
This PR adds ability to disable aggregates by default and enable/disable aggregates for specific tables.

## Performance impact

Unknown

## Security impact

Unknown

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [ ] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [X] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
