### PR TITLE
feat: add support for interval aggregation

### DIFF
--- a/src/AddAggregateTypesPlugin.ts
+++ b/src/AddAggregateTypesPlugin.ts
@@ -232,13 +232,14 @@ const Plugin: GraphileConfig.Plugin = {
                         //TODO: add more details here
                       },
                       () => {
+                        const attributeCodec = attribute.codec;
                         return {
                           description: `${spec.HumanLabel} of ${fieldName} across the matching connection`,
                           type: spec.isNonNull
                             ? new GraphQLNonNull(Type)
                             : Type,
                           plan: EXPORTABLE(
-                            (attributeName, codec, spec, sql) =>
+                            (attributeCodec, attributeName, codec, spec, sql) =>
                               function plan(
                                 $pgSelectSingle: PgSelectSingleStep
                               ) {
@@ -248,14 +249,16 @@ const Plugin: GraphileConfig.Plugin = {
                                 const sqlAttribute = sql.fragment`${
                                   $pgSelectSingle.getClassStep().alias
                                 }.${sql.identifier(attributeName)}`;
-                                const sqlAggregate =
-                                  spec.sqlAggregateWrap(sqlAttribute);
+                                const sqlAggregate = spec.sqlAggregateWrap(
+                                  sqlAttribute,
+                                  attributeCodec
+                                );
                                 return $pgSelectSingle.select(
                                   sqlAggregate,
                                   codec
                                 );
                               },
-                            [attributeName, codec, spec, sql]
+                            [attributeCodec, attributeName, codec, spec, sql]
                           ),
                         };
                       }
@@ -330,6 +333,7 @@ const Plugin: GraphileConfig.Plugin = {
                           args: makeFieldArgs(),
                           plan: EXPORTABLE(
                             (
+                              codec,
                               computedAttributeResource,
                               makeExpression,
                               spec,
@@ -352,13 +356,17 @@ const Plugin: GraphileConfig.Plugin = {
                                   ],
                                 });
 
-                                const sqlAggregate = spec.sqlAggregateWrap(src);
+                                const sqlAggregate = spec.sqlAggregateWrap(
+                                  src,
+                                  codec
+                                );
                                 return $pgSelectSingle.select(
                                   sqlAggregate,
                                   targetCodec
                                 );
                               },
                             [
+                              codec,
                               computedAttributeResource,
                               makeExpression,
                               spec,

--- a/src/AddHavingAggregateTypesPlugin.ts
+++ b/src/AddHavingAggregateTypesPlugin.ts
@@ -321,7 +321,8 @@ const Plugin: GraphileConfig.Plugin = {
                             }.${sql.identifier(attributeName)}`;
                             const aggregateExpression =
                               aggregateSpec.sqlAggregateWrap(
-                                attributeExpression
+                                attributeExpression,
+                                attribute.codec
                               );
                             return new BooleanFilterStep(
                               $having,
@@ -432,7 +433,10 @@ const Plugin: GraphileConfig.Plugin = {
                               });
 
                               const aggregateExpression =
-                                aggregateSpec.sqlAggregateWrap(src);
+                                aggregateSpec.sqlAggregateWrap(
+                                  src,
+                                  computedAttributeResource.codec
+                                );
                               const $filter = new BooleanFilterStep(
                                 $having,
                                 aggregateExpression

--- a/src/AggregateSpecsPlugin.ts
+++ b/src/AggregateSpecsPlugin.ts
@@ -82,8 +82,7 @@ export const PgAggregatesSpecsPlugin: GraphileConfig.Plugin = {
             HumanLabel: "Sum",
             isSuitableType: isIntervalLike || isNumberLike,
             // I've wrapped it in `coalesce` so that it cannot be null
-            sqlAggregateWrap: (sqlFrag) => sql`coalesce(sum(${sqlFrag}), 0)`,
-            isNonNull: true,
+            sqlAggregateWrap: (sqlFrag) => sql`sum(${sqlFrag})`,
 
             // A SUM(...) often ends up significantly larger than any individual
             // value; see

--- a/src/AggregateSpecsPlugin.ts
+++ b/src/AggregateSpecsPlugin.ts
@@ -18,7 +18,7 @@ const isNumberLike = (codec: PgCodec<any, any, any, any>): boolean =>
   !!codec.extensions?.isNumberLike;
 
 const isIntervalLike = (codec: PgCodec<any, any, any, any>): boolean =>
-!!codec.extensions?.isIntervalLike;
+  !!codec.extensions?.isIntervalLike || !!codec.extensions?.isNumberLike;
 
 export const PgAggregatesSpecsPlugin: GraphileConfig.Plugin = {
   name: "PgAggregatesSpecsPlugin",
@@ -35,11 +35,11 @@ export const PgAggregatesSpecsPlugin: GraphileConfig.Plugin = {
             pgCodec.extensions = Object.create(null);
           }
         }
-        if (pgType.typcategory === "N") {
-          pgCodec.extensions!.isNumberLike = true;
-        }
         if (pgType._id === INTERVAL_OID) {
           pgCodec.extensions!.isIntervalLike = true;
+        }
+        if (pgType.typcategory === "N") {
+          pgCodec.extensions!.isNumberLike = true;
         }
       },
     },
@@ -80,7 +80,7 @@ export const PgAggregatesSpecsPlugin: GraphileConfig.Plugin = {
             id: "sum",
             humanLabel: "sum",
             HumanLabel: "Sum",
-            isSuitableType: isNumberLike || isIntervalLike,
+            isSuitableType: isIntervalLike || isNumberLike,
             // I've wrapped it in `coalesce` so that it cannot be null
             sqlAggregateWrap: (sqlFrag) => sql`coalesce(sum(${sqlFrag}), 0)`,
             isNonNull: true,
@@ -118,21 +118,21 @@ export const PgAggregatesSpecsPlugin: GraphileConfig.Plugin = {
             id: "min",
             humanLabel: "minimum",
             HumanLabel: "Minimum",
-            isSuitableType: isNumberLike || isIntervalLike,
+            isSuitableType: isIntervalLike || isNumberLike,
             sqlAggregateWrap: (sqlFrag) => sql`min(${sqlFrag})`,
           },
           {
             id: "max",
             humanLabel: "maximum",
             HumanLabel: "Maximum",
-            isSuitableType: isNumberLike || isIntervalLike,
+            isSuitableType: isIntervalLike || isNumberLike,
             sqlAggregateWrap: (sqlFrag) => sql`max(${sqlFrag})`,
           },
           {
             id: "average",
             humanLabel: "mean average",
             HumanLabel: "Mean average",
-            isSuitableType: isNumberLike || isIntervalLike,
+            isSuitableType: isIntervalLike || isNumberLike,
             sqlAggregateWrap: (sqlFrag) => sql`avg(${sqlFrag})`,
 
             // An AVG(...) ends up more precise than any individual value; see

--- a/src/AggregateSpecsPlugin.ts
+++ b/src/AggregateSpecsPlugin.ts
@@ -81,7 +81,7 @@ export const PgAggregatesSpecsPlugin: GraphileConfig.Plugin = {
             id: "sum",
             humanLabel: "sum",
             HumanLabel: "Sum",
-            isSuitableType: isNumberLike,
+            isSuitableType: isNumberLike || isIntervalLike,
             // I've wrapped it in `coalesce` so that it cannot be null
             sqlAggregateWrap: (sqlFrag) => sql`coalesce(sum(${sqlFrag}), 0)`,
             isNonNull: true,
@@ -119,21 +119,21 @@ export const PgAggregatesSpecsPlugin: GraphileConfig.Plugin = {
             id: "min",
             humanLabel: "minimum",
             HumanLabel: "Minimum",
-            isSuitableType: isNumberLike,
+            isSuitableType: isNumberLike || isIntervalLike,
             sqlAggregateWrap: (sqlFrag) => sql`min(${sqlFrag})`,
           },
           {
             id: "max",
             humanLabel: "maximum",
             HumanLabel: "Maximum",
-            isSuitableType: isNumberLike,
+            isSuitableType: isNumberLike || isIntervalLike,
             sqlAggregateWrap: (sqlFrag) => sql`max(${sqlFrag})`,
           },
           {
             id: "average",
             humanLabel: "mean average",
             HumanLabel: "Mean average",
-            isSuitableType: isNumberLike,
+            isSuitableType: isNumberLike || isIntervalLike,
             sqlAggregateWrap: (sqlFrag) => sql`avg(${sqlFrag})`,
 
             // An AVG(...) ends up more precise than any individual value; see

--- a/src/AggregateSpecsPlugin.ts
+++ b/src/AggregateSpecsPlugin.ts
@@ -33,8 +33,11 @@ export const PgAggregatesSpecsPlugin: GraphileConfig.Plugin = {
     hooks: {
       pgCodecs_PgCodec(_info, event) {
         const { pgType, pgCodec } = event;
-        const isCatN = pgType.typcategory === "N";
-        const isInterval = pgType._id === INTERVAL_OID;
+        const isReg =
+          pgType.getNamespace()?.nspname === "pg_catalog" &&
+          pgType.typname.startsWith("reg");
+        const isCatN = !isReg && pgType.typcategory === "N";
+        const isInterval = !isReg && pgType._id === INTERVAL_OID;
         if (isCatN || isInterval) {
           if (!pgCodec.extensions) {
             pgCodec.extensions = Object.create(null);

--- a/src/AggregateSpecsPlugin.ts
+++ b/src/AggregateSpecsPlugin.ts
@@ -87,10 +87,7 @@ export const PgAggregatesSpecsPlugin: GraphileConfig.Plugin = {
             HumanLabel: "Sum",
             isSuitableType: isIntervalLikeOrNumberLike,
             // I've wrapped it in `coalesce` so that it cannot be null
-            sqlAggregateWrap: (sqlFrag, codec) =>
-              isIntervalLike(codec)
-                ? sql`coalesce(sum(${sqlFrag}), interval '0 seconds')`
-                : sql`coalesce(sum(${sqlFrag}), 0)`,
+            sqlAggregateWrap: (sqlFrag) => sql`coalesce(sum(${sqlFrag}), '0')`,
             isNonNull: true,
 
             // A SUM(...) often ends up significantly larger than any individual

--- a/src/AggregateSpecsPlugin.ts
+++ b/src/AggregateSpecsPlugin.ts
@@ -16,9 +16,9 @@ const { version } = require("../package.json");
 
 const isNumberLike = (codec: PgCodec<any, any, any, any>): boolean =>
   !!codec.extensions?.isNumberLike;
-
 const isIntervalLike = (codec: PgCodec<any, any, any, any>): boolean =>
   !!codec.extensions?.isIntervalLike;
+
 const isIntervalLikeOrNumberLike = (
   codec: PgCodec<any, any, any, any>
 ): boolean => isIntervalLike(codec) || isNumberLike(codec);

--- a/src/AggregateSpecsPlugin.ts
+++ b/src/AggregateSpecsPlugin.ts
@@ -17,7 +17,7 @@ const { version } = require("../package.json");
 const isNumberLike = (codec: PgCodec<any, any, any, any>): boolean =>
   !!codec.extensions?.isNumberLike;
 
-  const isIntervalLike = (codec: PgCodec<any, any, any, any>): boolean =>
+const isIntervalLike = (codec: PgCodec<any, any, any, any>): boolean =>
   !!codec.extensions?.isIntervalLike;
 
 export const PgAggregatesSpecsPlugin: GraphileConfig.Plugin = {

--- a/src/AggregateSpecsPlugin.ts
+++ b/src/AggregateSpecsPlugin.ts
@@ -17,6 +17,9 @@ const { version } = require("../package.json");
 const isNumberLike = (codec: PgCodec<any, any, any, any>): boolean =>
   !!codec.extensions?.isNumberLike;
 
+  const isIntervalLike = (codec: PgCodec<any, any, any, any>): boolean =>
+  !!codec.extensions?.isIntervalLike;
+
 export const PgAggregatesSpecsPlugin: GraphileConfig.Plugin = {
   name: "PgAggregatesSpecsPlugin",
   version,
@@ -32,6 +35,12 @@ export const PgAggregatesSpecsPlugin: GraphileConfig.Plugin = {
             pgCodec.extensions = Object.create(null);
           }
           pgCodec.extensions!.isNumberLike = true;
+        }
+        if (pgType.typcategory === "I") {
+          if (!pgCodec.extensions) {
+            pgCodec.extensions = Object.create(null);
+          }
+          pgCodec.extensions!.isIntervalLike = true;
         }
       },
     },

--- a/src/AggregateSpecsPlugin.ts
+++ b/src/AggregateSpecsPlugin.ts
@@ -17,9 +17,6 @@ const { version } = require("../package.json");
 const isNumberLike = (codec: PgCodec<any, any, any, any>): boolean =>
   !!codec.extensions?.isNumberLike;
 
-const isIntervalLike = (codec: PgCodec<any, any, any, any>): boolean =>
-  !!codec.extensions?.isIntervalLike;
-
 export const PgAggregatesSpecsPlugin: GraphileConfig.Plugin = {
   name: "PgAggregatesSpecsPlugin",
   version,
@@ -30,17 +27,11 @@ export const PgAggregatesSpecsPlugin: GraphileConfig.Plugin = {
     hooks: {
       pgCodecs_PgCodec(_info, event) {
         const { pgType, pgCodec } = event;
-        if (pgType.typcategory === "N") {
+        if (pgType.typcategory === "N" || pgType._id === INTERVAL_OID) {
           if (!pgCodec.extensions) {
             pgCodec.extensions = Object.create(null);
           }
           pgCodec.extensions!.isNumberLike = true;
-        }
-        if (pgType.typcategory === "I") {
-          if (!pgCodec.extensions) {
-            pgCodec.extensions = Object.create(null);
-          }
-          pgCodec.extensions!.isIntervalLike = true;
         }
       },
     },
@@ -81,7 +72,7 @@ export const PgAggregatesSpecsPlugin: GraphileConfig.Plugin = {
             id: "sum",
             humanLabel: "sum",
             HumanLabel: "Sum",
-            isSuitableType: isNumberLike || isIntervalLike,
+            isSuitableType: isNumberLike,
             // I've wrapped it in `coalesce` so that it cannot be null
             sqlAggregateWrap: (sqlFrag) => sql`coalesce(sum(${sqlFrag}), 0)`,
             isNonNull: true,
@@ -119,21 +110,21 @@ export const PgAggregatesSpecsPlugin: GraphileConfig.Plugin = {
             id: "min",
             humanLabel: "minimum",
             HumanLabel: "Minimum",
-            isSuitableType: isNumberLike || isIntervalLike,
+            isSuitableType: isNumberLike,
             sqlAggregateWrap: (sqlFrag) => sql`min(${sqlFrag})`,
           },
           {
             id: "max",
             humanLabel: "maximum",
             HumanLabel: "Maximum",
-            isSuitableType: isNumberLike || isIntervalLike,
+            isSuitableType: isNumberLike,
             sqlAggregateWrap: (sqlFrag) => sql`max(${sqlFrag})`,
           },
           {
             id: "average",
             humanLabel: "mean average",
             HumanLabel: "Mean average",
-            isSuitableType: isNumberLike || isIntervalLike,
+            isSuitableType: isNumberLike,
             sqlAggregateWrap: (sqlFrag) => sql`avg(${sqlFrag})`,
 
             // An AVG(...) ends up more precise than any individual value; see

--- a/src/AggregateSpecsPlugin.ts
+++ b/src/AggregateSpecsPlugin.ts
@@ -33,16 +33,18 @@ export const PgAggregatesSpecsPlugin: GraphileConfig.Plugin = {
     hooks: {
       pgCodecs_PgCodec(_info, event) {
         const { pgType, pgCodec } = event;
-        if (pgType.typcategory === "N" || pgType._id === INTERVAL_OID) {
+        const isCatN = pgType.typcategory === "N";
+        const isInterval = pgType._id === INTERVAL_OID;
+        if (isCatN || isInterval) {
           if (!pgCodec.extensions) {
             pgCodec.extensions = Object.create(null);
           }
         }
-        if (pgType._id === INTERVAL_OID) {
-          pgCodec.extensions!.isIntervalLike = true;
-        }
-        if (pgType.typcategory === "N") {
+        if (isCatN) {
           pgCodec.extensions!.isNumberLike = true;
+        }
+        if (isInterval) {
+          pgCodec.extensions!.isIntervalLike = true;
         }
       },
     },

--- a/src/FilterRelationalAggregatesPlugin.ts
+++ b/src/FilterRelationalAggregatesPlugin.ts
@@ -543,7 +543,8 @@ group by true)`;
                             expression: spec.sqlAggregateWrap(
                               sql`${$col.alias}.${sql.identifier(
                                 attributeName
-                              )}`
+                              )}`,
+                              attribute.codec
                             ),
                           };
 

--- a/src/OrderByAggregatesPlugin.ts
+++ b/src/OrderByAggregatesPlugin.ts
@@ -185,7 +185,8 @@ where ${sql.parens(
 select ${aggregateSpec.sqlAggregateWrap(
                       sql.fragment`${tableAlias}.${sql.identifier(
                         attributeName
-                      )}`
+                      )}`,
+                      attribute.codec
                     )}
 from ${table.from} ${tableAlias}
 where ${sql.join(

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -5,7 +5,6 @@ declare global {
   namespace DataplanPg {
     interface PgCodecExtensions {
       isNumberLike?: boolean;
-      isIntervalLike?: boolean;
     }
     interface PgConditionStepExtensions {
       pgFilterAttribute?: {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -5,6 +5,7 @@ declare global {
   namespace DataplanPg {
     interface PgCodecExtensions {
       isNumberLike?: boolean;
+      isIntervalLike?: boolean;
     }
     interface PgConditionStepExtensions {
       pgFilterAttribute?: {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -112,7 +112,7 @@ export interface AggregateSpec {
   shouldApplyToEntity?: (entity: AggregateTargetEntity) => boolean;
 
   /** Wraps the SQL in an aggregate call */
-  sqlAggregateWrap: (sqlFrag: SQL) => SQL;
+  sqlAggregateWrap: (sqlFrag: SQL, codec: PgCodec<any, any, any, any>) => SQL;
 
   /**
    * Used to translate the PostgreSQL return type for the aggregate; for example:


### PR DESCRIPTION
## Description
Expands the AggregateSpecsPlugin to check for Interval types as well as numeric.

Possible breaking change:
I removed the isNonNull requirement and the coalesce from Sum. Now people who were properly getting their aggregates coalsced into 0 will now receive null.

## Performance impact

Unknown

## Security impact

Unknown

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

This will be my first contribution so please let me know if I missed anything, it seemed relatively simple though!
