### PR TITLE
Enable control of which fields get added to the schema via behaviors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -79,7 +79,6 @@ module.exports = {
     // note you must disable the base rule as it can report incorrect errors
     "no-duplicate-imports": "off",
     "import/no-duplicates": "off",
-    "@typescript-eslint/no-duplicate-imports": ["error"],
   },
   overrides: [
     // Rules for TypeScript only

--- a/README.md
+++ b/README.md
@@ -428,11 +428,11 @@ more information.
 
 ## Disable aggregates
 
-By default, aggregates are created for all tables. This significantly increases
-the size of your GraphQL schema, and could also be a security (DoS) concern as
-aggregates can be expensive. We recommend that you use the `-aggregates` default
-behavior to disable aggregates by default, and then enable them only for the
-tables you need:
+By default, aggregates are created for all tables, all columns, and all computed
+column functions. This significantly increases the size of your GraphQL schema,
+and could also be a security (DoS) concern as aggregates can be expensive. We
+recommend that you use the `-aggregates` default behavior to disable aggregates
+by default, and then enable them only for the tables you need:
 
 (This currently doesn't work due to a
 [bug in PostGraphile that's being worked on](https://github.com/graphile/crystal/pull/1803).)
@@ -448,14 +448,40 @@ export default {
 };
 ```
 
+For the specific aggregate behavior strings available, please see the
+[PostGraphile behavior documentation](https://postgraphile.org/postgraphile/next/behavior).
+
+The `aggregates` behavior is used to enable/disable the 'aggregates' field
+appearing on a table's connections.
+
+The `groupedAggregates` behavior is used to enable/disable the
+'groupedAggregates' field appearing on a table's connections.
+
+The `having` behavior is used to enable/disable the `having` filter on the
+'groupedAggregates' field appearing on a table's connections.
+
+The `aggregate` behavior is used to enable/disable a specific attribute (or
+computed column) from being aggregated on.
+
+The `groupBy` behavior is used to enable/disable a specific attribute (or
+computed column) from being used as the grouping clause in a grouped aggregate.
+
+The `havingBy` behavior is used to enable/disable aggregates of a specific
+attribute (or computed column) from being used in the having clause of a grouped
+aggregate.
+
 The `aggregates:filterBy` behavior is used to enable/disable the
-[filtering by aggregates](#filtering-by-aggregates)
+[filtering by aggregates](#filtering-by-aggregates) in general (e.g. used on
+tables, relationships), and the `aggregate:filterBy` behavior is used to
+enable/disable filtering by a specific aggregate (e.g. used on attributes,
+computed columns). You can further scope these, for example adding the behavior
+`-sum:attribute:aggregate:filterBy` to a specific column would disable filtering
+by the `sum` aggregate of this column whilst leaving all other aggregates as is.
 
 The `aggregates:orderBy` behavior is used to enable/disable the
-[ordering by aggregates](#ordering-by-aggregates)
-
-You can use any combination of `aggregates`, `aggregates:filterBy` and
-`aggregates:orderBy` behaviors.
+[ordering by aggregates](#ordering-by-aggregates) in general (e.g. used on
+tables, relationships), and the `aggregate:orderBy` is used to enable/disable
+ordering by a specific aggregate (e.g. used on attributes, computed columns).
 
 Enable aggregates for a specific table:
 

--- a/README.md
+++ b/README.md
@@ -460,8 +460,25 @@ The `groupedAggregates` behavior is used to enable/disable the
 The `having` behavior is used to enable/disable the `having` filter on the
 'groupedAggregates' field appearing on a table's connections.
 
-The `aggregate` behavior is used to enable/disable a specific attribute (or
-computed column) from being aggregated on.
+The `aggregates:filterBy` behavior is used to enable/disable the
+[filtering by aggregates](#filtering-by-aggregates) in general (e.g. used on
+tables, relationships).
+
+The `aggregates:orderBy` behavior is used to enable/disable the
+[ordering by aggregates](#ordering-by-aggregates) in general (e.g. used on
+tables, relationships).
+
+The `aggregate` (note: singular!) behavior is used to enable/disable a specific
+attribute (or computed column) from being aggregated on.
+
+The `aggregate:filterBy` behavior is used to enable/disable filtering by a
+specific aggregate (e.g. used on attributes, computed columns). You can further
+scope these, for example adding the behavior `-sum:attribute:aggregate:filterBy`
+to a specific column would disable filtering by the `sum` aggregate of this
+column whilst leaving all other aggregates as is.
+
+The `aggregate:orderBy` is used to enable/disable ordering by a specific
+aggregate (e.g. used on attributes, computed columns).
 
 The `groupBy` behavior is used to enable/disable a specific attribute (or
 computed column) from being used as the grouping clause in a grouped aggregate.
@@ -469,19 +486,6 @@ computed column) from being used as the grouping clause in a grouped aggregate.
 The `havingBy` behavior is used to enable/disable aggregates of a specific
 attribute (or computed column) from being used in the having clause of a grouped
 aggregate.
-
-The `aggregates:filterBy` behavior is used to enable/disable the
-[filtering by aggregates](#filtering-by-aggregates) in general (e.g. used on
-tables, relationships), and the `aggregate:filterBy` behavior is used to
-enable/disable filtering by a specific aggregate (e.g. used on attributes,
-computed columns). You can further scope these, for example adding the behavior
-`-sum:attribute:aggregate:filterBy` to a specific column would disable filtering
-by the `sum` aggregate of this column whilst leaving all other aggregates as is.
-
-The `aggregates:orderBy` behavior is used to enable/disable the
-[ordering by aggregates](#ordering-by-aggregates) in general (e.g. used on
-tables, relationships), and the `aggregate:orderBy` is used to enable/disable
-ordering by a specific aggregate (e.g. used on attributes, computed columns).
 
 Enable aggregates for a specific table:
 

--- a/README.md
+++ b/README.md
@@ -428,11 +428,12 @@ more information.
 
 ## Disable aggregates
 
-By default, aggregates are created for all tables, all columns, and all computed
-column functions. This significantly increases the size of your GraphQL schema,
-and could also be a security (DoS) concern as aggregates can be expensive. We
-recommend that you use the `-aggregates` default behavior to disable aggregates
-by default, and then enable them only for the tables you need:
+By default, aggregates are created for all suitable tables, all suitable
+columns, and all suitable computed column functions. This significantly
+increases the size of your GraphQL schema, and could also be a security (DoS)
+concern as aggregates can be expensive. We recommend that you use the
+`-aggregates` default behavior to disable aggregates by default, and then enable
+them only for the tables you need:
 
 (This currently doesn't work due to a
 [bug in PostGraphile that's being worked on](https://github.com/graphile/crystal/pull/1803).)

--- a/package.json
+++ b/package.json
@@ -55,8 +55,10 @@
   },
   "devDependencies": {
     "@types/node": "^18.15.11",
+    "@typescript-eslint/eslint-plugin": "^7.9.0",
+    "@typescript-eslint/parser": "^7.9.0",
     "concurrently": "^5.3.0",
-    "eslint": "^8.44.0",
+    "eslint": "8.x",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-graphile-export": "^0.0.2-beta.3",
     "eslint-plugin-graphql": "^4.0.0",

--- a/src/AddAggregateTypesPlugin.ts
+++ b/src/AddAggregateTypesPlugin.ts
@@ -25,7 +25,7 @@ const isSuitableSource = (
     return false;
   }
 
-  return !!build.behavior.pgResourceMatches(resource, "aggregates");
+  return !!build.behavior.pgResourceMatches(resource, "resource:aggregates");
 };
 const Plugin: GraphileConfig.Plugin = {
   name: "PgAggregatesAddAggregateTypesPlugin",
@@ -39,6 +39,8 @@ attributes and computed columns.`,
   // Create the aggregates type for each table
   schema: {
     entityBehavior: {
+      // `aggregates` - for collection resources (e.g. returning a setof records)
+      // `aggregate` - for computed column resources (e.g. returning a scalar)
       pgResource: "select aggregates aggregate",
       pgCodecAttribute: "aggregate",
     },
@@ -105,6 +107,14 @@ attributes and computed columns.`,
               resource: resource,
               aggregateSpec,
             });
+            if (
+              !build.behavior.pgResourceMatches(
+                resource,
+                `${aggregateSpec.id}:resource:aggregates`
+              )
+            ) {
+              continue;
+            }
             build.registerObjectType(
               aggregateTypeName,
               {

--- a/src/AddConnectionAggregatesPlugin.ts
+++ b/src/AddConnectionAggregatesPlugin.ts
@@ -6,6 +6,7 @@ const { version } = require("../package.json");
 
 const Plugin: GraphileConfig.Plugin = {
   name: "PgAggregatesAddConnectionAggregatesPlugin",
+  description: "Adds the `aggregates` field to connections.",
   version,
   provides: ["aggregates"],
 
@@ -38,6 +39,10 @@ const Plugin: GraphileConfig.Plugin = {
           table.parameters ||
           !table.codec.attributes
         ) {
+          return fields;
+        }
+
+        if (!build.behavior.pgResourceMatches(table, `resource:aggregates`)) {
           return fields;
         }
 

--- a/src/AddConnectionGroupedAggregatesPlugin.ts
+++ b/src/AddConnectionGroupedAggregatesPlugin.ts
@@ -25,6 +25,7 @@ function isValidEnum(
 
 const Plugin: GraphileConfig.Plugin = {
   name: "PgAggregatesAddConnectionGroupedAggregatesPlugin",
+  description: "Adds the groupedAggregates field to connections.",
   version,
   provides: ["aggregates"],
 
@@ -60,6 +61,12 @@ const Plugin: GraphileConfig.Plugin = {
           !table ||
           table.parameters ||
           !table.codec.attributes
+        ) {
+          return fields;
+        }
+
+        if (
+          !build.behavior.pgResourceMatches(table, `resource:groupedAggregates`)
         ) {
           return fields;
         }

--- a/src/AddGroupByAggregateEnumValuesForAttributesPlugin.ts
+++ b/src/AddGroupByAggregateEnumValuesForAttributesPlugin.ts
@@ -20,7 +20,7 @@ const Plugin: GraphileConfig.Plugin = {
   // Now add group by attributes
   schema: {
     entityBehavior: {
-      pgCodecAttribute: "order aggregate:groupBy",
+      pgCodecAttribute: "order groupBy",
     },
     hooks: {
       GraphQLEnumType_values(values, build, context) {
@@ -53,7 +53,7 @@ const Plugin: GraphileConfig.Plugin = {
               if (
                 !build.behavior.pgCodecAttributeMatches(
                   [table.codec, attributeName],
-                  `attribute:aggregate:groupBy`
+                  `attribute:groupBy`
                 )
               ) {
                 return memo;

--- a/src/AddGroupByAggregateEnumValuesForAttributesPlugin.ts
+++ b/src/AddGroupByAggregateEnumValuesForAttributesPlugin.ts
@@ -12,13 +12,15 @@ const { version } = require("../package.json");
 
 const Plugin: GraphileConfig.Plugin = {
   name: "PgAggregatesAddGroupByAggregateEnumValuesForAttributesPlugin",
+  description:
+    "Adds values representing table attributes to the enum that defines the groupedAggregates groupings.",
   version,
   provides: ["aggregates"],
 
   // Now add group by attributes
   schema: {
     entityBehavior: {
-      pgCodecAttribute: "order",
+      pgCodecAttribute: "order aggregate:groupBy",
     },
     hooks: {
       GraphQLEnumType_values(values, build, context) {
@@ -44,6 +46,14 @@ const Plugin: GraphileConfig.Plugin = {
                 !build.behavior.pgCodecAttributeMatches(
                   [table.codec, attributeName],
                   "order"
+                )
+              ) {
+                return memo;
+              }
+              if (
+                !build.behavior.pgCodecAttributeMatches(
+                  [table.codec, attributeName],
+                  `attribute:aggregate:groupBy`
                 )
               ) {
                 return memo;
@@ -82,6 +92,7 @@ const Plugin: GraphileConfig.Plugin = {
                 `Adding groupBy enum value for ${table.name}.${attributeName}.`
               );
 
+              // Derivatives of this attribute
               pgAggregateGroupBySpecs.forEach((aggregateGroupBySpec) => {
                 if (
                   (!aggregateGroupBySpec.shouldApplyToEntity ||

--- a/src/AddGroupByAggregateEnumsPlugin.ts
+++ b/src/AddGroupByAggregateEnumsPlugin.ts
@@ -2,12 +2,13 @@ const { version } = require("../package.json");
 
 const Plugin: GraphileConfig.Plugin = {
   name: "PgAggregatesAddGroupByAggregateEnumsPlugin",
+  description: "Creates the enum types used for grouping in groupedAggregates.",
   version,
   provides: ["aggregates"],
 
   schema: {
     entityBehavior: {
-      pgResource: "select order",
+      pgResource: "select order groupedAggregates",
     },
 
     hooks: {
@@ -29,6 +30,14 @@ const Plugin: GraphileConfig.Plugin = {
             continue;
           }
           if (!build.behavior.pgResourceMatches(resource, "order")) {
+            continue;
+          }
+          if (
+            !build.behavior.pgResourceMatches(
+              resource,
+              "resource:groupedAggregates"
+            )
+          ) {
             continue;
           }
 

--- a/src/AddHavingAggregateTypesPlugin.ts
+++ b/src/AddHavingAggregateTypesPlugin.ts
@@ -29,7 +29,10 @@ columns.`,
 
   schema: {
     entityBehavior: {
-      pgResource: "order having",
+      // having - for connections' groupedAggregates field
+      // havingBy - for computed column functions acting like attributes
+      pgResource: "order having havingBy",
+      pgCodecAttribute: "havingBy",
     },
 
     hooks: {
@@ -320,7 +323,7 @@ columns.`,
                         if (
                           !build.behavior.pgCodecAttributeMatches(
                             [resource.codec, attributeName],
-                            "attribute:groupedAggregates:havingBy"
+                            "attribute:havingBy"
                           )
                         ) {
                           return newFields;
@@ -392,7 +395,7 @@ columns.`,
                         if (
                           !build.behavior.pgResourceMatches(
                             computedAttributeResource,
-                            "resource:groupedAggregates:havingBy"
+                            "resource:havingBy"
                           )
                         ) {
                           return memo;

--- a/src/AggregateSpecsPlugin.ts
+++ b/src/AggregateSpecsPlugin.ts
@@ -29,6 +29,8 @@ const isIntervalLikeOrNumberLike = EXPORTABLE(
 
 export const PgAggregatesSpecsPlugin: GraphileConfig.Plugin = {
   name: "PgAggregatesSpecsPlugin",
+  description:
+    "Created the default (extensible) aggregate specs and group-by specs used throughout this preset.",
   version,
   provides: ["aggregates"],
   after: ["PgBasicsPlugin"],

--- a/src/AggregatesSmartTagsPlugin.ts
+++ b/src/AggregatesSmartTagsPlugin.ts
@@ -55,13 +55,13 @@ function processTags(
     case "on":
       addBehaviorToTags(
         tags,
-        "+aggregates +aggregates:filter +aggregates:order +aggregate +aggregate:filterBy +aggregate:orderBy"
+        "+aggregates +aggregates:filterBy +aggregates:orderBy +aggregate +aggregate:filterBy +aggregate:orderBy"
       );
       break;
     case "off":
       addBehaviorToTags(
         tags,
-        "-aggregates -aggregates:filter -aggregates:order -aggregate -aggregate:filterBy -aggregate:orderBy"
+        "-aggregates -aggregates:filterBy -aggregates:orderBy -aggregate -aggregate:filterBy -aggregate:orderBy"
       );
       break;
   }

--- a/src/AggregatesSmartTagsPlugin.ts
+++ b/src/AggregatesSmartTagsPlugin.ts
@@ -55,13 +55,13 @@ function processTags(
     case "on":
       addBehaviorToTags(
         tags,
-        "+aggregates +aggregates:filterBy +aggregates:orderBy"
+        "+aggregates +aggregates:filter +aggregates:order +aggregate +aggregate:filterBy +aggregate:orderBy"
       );
       break;
     case "off":
       addBehaviorToTags(
         tags,
-        "-aggregates -aggregates:filterBy -aggregates:orderBy"
+        "-aggregates -aggregates:filter -aggregates:order -aggregate -aggregate:filterBy -aggregate:orderBy"
       );
       break;
   }

--- a/src/FilterRelationalAggregatesPlugin.ts
+++ b/src/FilterRelationalAggregatesPlugin.ts
@@ -58,7 +58,8 @@ the sum of their points scored.`,
 
   schema: {
     entityBehavior: {
-      pgResource: "aggregates:filterBy",
+      pgResource: "aggregates:filter aggregate:filterBy",
+      pgCodecAttribute: "aggregate:filterBy",
     },
 
     hooks: {
@@ -526,6 +527,14 @@ group by true)`;
             {
               ...Object.entries(attributes).reduce(
                 (memo, [attributeName, attribute]) => {
+                  if (
+                    !build.behavior.pgCodecAttributeMatches(
+                      [table.codec, attributeName],
+                      `${spec.id}:attribute:aggregate:filterBy`
+                    )
+                  ) {
+                    return memo;
+                  }
                   if (
                     (spec.shouldApplyToEntity &&
                       !spec.shouldApplyToEntity({

--- a/src/FilterRelationalAggregatesPlugin.ts
+++ b/src/FilterRelationalAggregatesPlugin.ts
@@ -208,7 +208,7 @@ the sum of their points scored.`,
 select ${boolExpr}
 from ${this.tableExpression} as ${this.alias}
 ${where}`}
-group by true)`;
+group by ())`;
                 return this.$parent.where(subquery);
               }
             } as PgAggregateConditionStepClass,

--- a/src/FilterRelationalAggregatesPlugin.ts
+++ b/src/FilterRelationalAggregatesPlugin.ts
@@ -31,6 +31,10 @@ declare global {
 
 export const Plugin: GraphileConfig.Plugin = {
   name: "PgAggregatesFilterRelationalAggregatesPlugin",
+  description: `\
+Adds the ability to filter a collection by aggregates on relationships if you \
+have postgraphile-plugin-connection-filter, e.g. filtering all players based on \
+the sum of their points scored.`,
   version,
 
   // This has to run AFTER any plugins that provide `build.pgAggregateSpecs`
@@ -242,7 +246,7 @@ group by true)`;
           if (
             !build.behavior.pgResourceMatches(
               foreignTable,
-              "aggregates:filterBy"
+              "resource:aggregates:filterBy"
             )
           ) {
             continue;
@@ -306,6 +310,14 @@ group by true)`;
 
           // Register the aggregate spec filter type for each aggreage spec for each source
           for (const spec of build.pgAggregateSpecs) {
+            if (
+              !build.behavior.pgResourceMatches(
+                foreignTable,
+                `${spec.id}:resource:aggregates:filterBy`
+              )
+            ) {
+              continue;
+            }
             const filterTypeName = inflection.filterTableAggregateType(
               foreignTable,
               spec

--- a/src/FilterRelationalAggregatesPlugin.ts
+++ b/src/FilterRelationalAggregatesPlugin.ts
@@ -58,7 +58,7 @@ the sum of their points scored.`,
 
   schema: {
     entityBehavior: {
-      pgResource: "aggregates:filter aggregate:filterBy",
+      pgResource: "aggregates:filterBy aggregate:filterBy",
       pgCodecAttribute: "aggregate:filterBy",
     },
 

--- a/src/InflectionPlugin.ts
+++ b/src/InflectionPlugin.ts
@@ -127,6 +127,7 @@ declare global {
 
 export const PgAggregatesInflectorsPlugin: GraphileConfig.Plugin = {
   name: "PgAggregatesInflectorsPlugin",
+  description: "Adds the inflectors used by the pg-aggregates preset.",
   version,
   provides: ["aggregates"],
 

--- a/src/OrderByAggregatesPlugin.ts
+++ b/src/OrderByAggregatesPlugin.ts
@@ -154,6 +154,17 @@ where ${sql.parens(
               for (const [attributeName, attribute] of Object.entries(
                 table.codec.attributes as PgCodecAttributes
               )) {
+                if (
+                  (aggregateSpec.shouldApplyToEntity &&
+                    !aggregateSpec.shouldApplyToEntity({
+                      type: "attribute",
+                      codec: table.codec,
+                      attributeName: attributeName,
+                    })) ||
+                  !aggregateSpec.isSuitableType(attribute.codec)
+                ) {
+                  continue;
+                }
                 const baseName =
                   inflection.orderByAttributeAggregateOfManyRelationByKeys({
                     registry: foreignTable.registry,

--- a/src/OrderByAggregatesPlugin.ts
+++ b/src/OrderByAggregatesPlugin.ts
@@ -1,5 +1,4 @@
 import type {
-  PgCodecAttributes,
   PgCodecRelation,
   PgCodecWithAttributes,
   PgResource,

--- a/src/OrderByAggregatesPlugin.ts
+++ b/src/OrderByAggregatesPlugin.ts
@@ -21,7 +21,9 @@ export const PgAggregatesOrderByAggregatesPlugin: GraphileConfig.Plugin = {
 
   schema: {
     entityBehavior: {
+      pgResource: "relatedAggregates:orderBy",
       pgCodecRelation: "select aggregates:orderBy",
+      pgCodecAttribute: "aggregate:orderBy",
     },
 
     hooks: {
@@ -49,6 +51,14 @@ export const PgAggregatesOrderByAggregatesPlugin: GraphileConfig.Plugin = {
           !foreignTable ||
           foreignTable.parameters ||
           !foreignTable.codec.attributes
+        ) {
+          return values;
+        }
+        if (
+          !build.behavior.pgResourceMatches(
+            foreignTable,
+            "resource:relatedAggregates:orderBy"
+          )
         ) {
           return values;
         }
@@ -163,6 +173,9 @@ where ${sql.parens(
                   `${aggregateSpec.id}:manyRelation:aggregates:orderBy`
                 )
               ) {
+                console.log(
+                  `Aggregate ${aggregateSpec.id} not permitted on ${relationName}`
+                );
                 return memo;
               }
               for (const [attributeName, attribute] of Object.entries(
@@ -171,10 +184,13 @@ where ${sql.parens(
                 if (
                   !build.behavior.pgCodecAttributeMatches(
                     [table.codec, attributeName],
-                    `${aggregateSpec.id}:attribute:aggregates:orderBy`
+                    `${aggregateSpec.id}:attribute:aggregate:orderBy`
                   )
                 ) {
-                  return memo;
+                  console.log(
+                    `Aggregate ${aggregateSpec.id} not permitted on ${table.codec.name}.${attributeName} (${aggregateSpec.id}:attribute:aggregate:orderBy)`
+                  );
+                  continue;
                 }
                 if (
                   (aggregateSpec.shouldApplyToEntity &&

--- a/src/OrderByAggregatesPlugin.ts
+++ b/src/OrderByAggregatesPlugin.ts
@@ -172,10 +172,7 @@ where ${sql.parens(
                   `${aggregateSpec.id}:manyRelation:aggregates:orderBy`
                 )
               ) {
-                console.log(
-                  `Aggregate ${aggregateSpec.id} not permitted on ${relationName}`
-                );
-                return memo;
+                return;
               }
               for (const [attributeName, attribute] of Object.entries(
                 table.codec.attributes
@@ -186,9 +183,6 @@ where ${sql.parens(
                     `${aggregateSpec.id}:attribute:aggregate:orderBy`
                   )
                 ) {
-                  console.log(
-                    `Aggregate ${aggregateSpec.id} not permitted on ${table.codec.name}.${attributeName} (${aggregateSpec.id}:attribute:aggregate:orderBy)`
-                  );
                   continue;
                 }
                 if (

--- a/yarn.lock
+++ b/yarn.lock
@@ -75,22 +75,22 @@
     ts-node "^9"
     tslib "^2"
 
-"@eslint-community/eslint-utils@^4.2.0":
+"@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
   integrity sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==
   dependencies:
     eslint-visitor-keys "^3.3.0"
 
-"@eslint-community/regexpp@^4.4.0":
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.5.1.tgz#cdd35dce4fa1a89a4fd42b1599eb35b3af408884"
-  integrity sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==
+"@eslint-community/regexpp@^4.10.0", "@eslint-community/regexpp@^4.6.1":
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.10.0.tgz#548f6de556857c8bb73bbee70c35dc82a2e74d63"
+  integrity sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==
 
-"@eslint/eslintrc@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-2.1.0.tgz#82256f164cc9e0b59669efc19d57f8092706841d"
-  integrity sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==
+"@eslint/eslintrc@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-2.1.4.tgz#388a269f0f25c1b6adc317b5a2c55714894c70ad"
+  integrity sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==
   dependencies:
     ajv "^6.12.4"
     debug "^4.3.2"
@@ -102,10 +102,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eslint/js@8.44.0":
-  version "8.44.0"
-  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.44.0.tgz#961a5903c74139390478bdc808bcde3fc45ab7af"
-  integrity sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==
+"@eslint/js@8.57.0":
+  version "8.57.0"
+  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.0.tgz#a5417ae8427873f1dd08b70b3574b453e67b5f7f"
+  integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
 "@graphile/lru@^5.0.0-beta.1":
   version "5.0.0-beta.1"
@@ -295,13 +295,13 @@
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.2.0.tgz#5f3d96ec6b2354ad6d8a28bf216a1d97b5426861"
   integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
 
-"@humanwhocodes/config-array@^0.11.10":
-  version "0.11.10"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.10.tgz#5a3ffe32cc9306365fb3fd572596cd602d5e12d2"
-  integrity sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==
+"@humanwhocodes/config-array@^0.11.14":
+  version "0.11.14"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.14.tgz#d78e481a039f7566ecc9660b4ea7fe6b1fec442b"
+  integrity sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==
   dependencies:
-    "@humanwhocodes/object-schema" "^1.2.1"
-    debug "^4.1.1"
+    "@humanwhocodes/object-schema" "^2.0.2"
+    debug "^4.3.1"
     minimatch "^3.0.5"
 
 "@humanwhocodes/module-importer@^1.0.1":
@@ -309,10 +309,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz#af5b2691a22b44be847b0ca81641c5fb6ad0172c"
   integrity sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==
 
-"@humanwhocodes/object-schema@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
-  integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
+"@humanwhocodes/object-schema@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz#4a2868d75d6d6963e423bcf90b7fd1be343409d3"
+  integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
 
 "@iarna/toml@^2.2.5":
   version "2.2.5"
@@ -418,6 +418,32 @@
   dependencies:
     "@types/node" "*"
 
+"@typescript-eslint/eslint-plugin@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.9.0.tgz#093b96fc4e342226e65d5f18f9c87081e0b04a31"
+  integrity sha512-6e+X0X3sFe/G/54aC3jt0txuMTURqLyekmEHViqyA2VnxhLMpvA6nqmcjIy+Cr9tLDHPssA74BP5Mx9HQIxBEA==
+  dependencies:
+    "@eslint-community/regexpp" "^4.10.0"
+    "@typescript-eslint/scope-manager" "7.9.0"
+    "@typescript-eslint/type-utils" "7.9.0"
+    "@typescript-eslint/utils" "7.9.0"
+    "@typescript-eslint/visitor-keys" "7.9.0"
+    graphemer "^1.4.0"
+    ignore "^5.3.1"
+    natural-compare "^1.4.0"
+    ts-api-utils "^1.3.0"
+
+"@typescript-eslint/parser@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-7.9.0.tgz#fb3ba01b75e0e65cb78037a360961b00301f6c70"
+  integrity sha512-qHMJfkL5qvgQB2aLvhUSXxbK7OLnDkwPzFalg458pxQgfxKDfT1ZDbHQM/I6mDIf/svlMkj21kzKuQ2ixJlatQ==
+  dependencies:
+    "@typescript-eslint/scope-manager" "7.9.0"
+    "@typescript-eslint/types" "7.9.0"
+    "@typescript-eslint/typescript-estree" "7.9.0"
+    "@typescript-eslint/visitor-keys" "7.9.0"
+    debug "^4.3.4"
+
 "@typescript-eslint/scope-manager@5.61.0":
   version "5.61.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.61.0.tgz#b670006d069c9abe6415c41f754b1b5d949ef2b2"
@@ -426,10 +452,33 @@
     "@typescript-eslint/types" "5.61.0"
     "@typescript-eslint/visitor-keys" "5.61.0"
 
+"@typescript-eslint/scope-manager@7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-7.9.0.tgz#1dd3e63a4411db356a9d040e75864851b5f2619b"
+  integrity sha512-ZwPK4DeCDxr3GJltRz5iZejPFAAr4Wk3+2WIBaj1L5PYK5RgxExu/Y68FFVclN0y6GGwH8q+KgKRCvaTmFBbgQ==
+  dependencies:
+    "@typescript-eslint/types" "7.9.0"
+    "@typescript-eslint/visitor-keys" "7.9.0"
+
+"@typescript-eslint/type-utils@7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-7.9.0.tgz#f523262e1b66ca65540b7a65a1222db52e0a90c9"
+  integrity sha512-6Qy8dfut0PFrFRAZsGzuLoM4hre4gjzWJB6sUvdunCYZsYemTkzZNwF1rnGea326PHPT3zn5Lmg32M/xfJfByA==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "7.9.0"
+    "@typescript-eslint/utils" "7.9.0"
+    debug "^4.3.4"
+    ts-api-utils "^1.3.0"
+
 "@typescript-eslint/types@5.61.0":
   version "5.61.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.61.0.tgz#e99ff11b5792d791554abab0f0370936d8ca50c0"
   integrity sha512-ldyueo58KjngXpzloHUog/h9REmHl59G1b3a5Sng1GfBo14BkS3ZbMEb3693gnP1k//97lh7bKsp6/V/0v1veQ==
+
+"@typescript-eslint/types@7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-7.9.0.tgz#b58e485e4bfba055659c7e683ad4f5f0821ae2ec"
+  integrity sha512-oZQD9HEWQanl9UfsbGVcZ2cGaR0YT5476xfWE0oE5kQa2sNK2frxOlkeacLOTh9po4AlUT5rtkGyYM5kew0z5w==
 
 "@typescript-eslint/typescript-estree@5.61.0":
   version "5.61.0"
@@ -443,6 +492,30 @@
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
+
+"@typescript-eslint/typescript-estree@7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-7.9.0.tgz#3395e27656060dc313a6b406c3a298b729685e07"
+  integrity sha512-zBCMCkrb2YjpKV3LA0ZJubtKCDxLttxfdGmwZvTqqWevUPN0FZvSI26FalGFFUZU/9YQK/A4xcQF9o/VVaCKAg==
+  dependencies:
+    "@typescript-eslint/types" "7.9.0"
+    "@typescript-eslint/visitor-keys" "7.9.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    minimatch "^9.0.4"
+    semver "^7.6.0"
+    ts-api-utils "^1.3.0"
+
+"@typescript-eslint/utils@7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-7.9.0.tgz#1b96a34eefdca1c820cb1bbc2751d848b4540899"
+  integrity sha512-5KVRQCzZajmT4Ep+NEgjXCvjuypVvYHUW7RHlXzNPuak2oWpVoD1jf5xCP0dPAuNIchjC7uQyvbdaSTFaLqSdA==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.4.0"
+    "@typescript-eslint/scope-manager" "7.9.0"
+    "@typescript-eslint/types" "7.9.0"
+    "@typescript-eslint/typescript-estree" "7.9.0"
 
 "@typescript-eslint/utils@^5.10.0":
   version "5.61.0"
@@ -466,6 +539,19 @@
     "@typescript-eslint/types" "5.61.0"
     eslint-visitor-keys "^3.3.0"
 
+"@typescript-eslint/visitor-keys@7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-7.9.0.tgz#82162656e339c3def02895f5c8546f6888d9b9ea"
+  integrity sha512-iESPx2TNLDNGQLyjKhUvIKprlP49XNEK+MvIf9nIO7ZZaZdbnfWKHnXAgufpxqfA0YryH8XToi4+CjBgVnFTSQ==
+  dependencies:
+    "@typescript-eslint/types" "7.9.0"
+    eslint-visitor-keys "^3.4.3"
+
+"@ungap/structured-clone@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
+  integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -484,11 +570,11 @@ acorn-jsx@^5.3.2:
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
 acorn@^8.9.0:
-  version "8.10.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
-  integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
+  version "8.11.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.3.tgz#71e0b14e13a4ec160724b38fb7b0f233b1b81d7a"
+  integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
 
-ajv@^6.10.0, ajv@^6.12.4, ajv@~6.12.6:
+ajv@^6.12.4, ajv@~6.12.6:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -628,6 +714,13 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
 
 braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
@@ -852,7 +945,7 @@ debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.1.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
+debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -1099,40 +1192,46 @@ eslint-scope@^5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-scope@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.0.tgz#f21ebdafda02352f103634b96dd47d9f81ca117b"
-  integrity sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==
+eslint-scope@^7.2.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.2.tgz#deb4f92563390f32006894af62a22dba1c46423f"
+  integrity sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
 
-eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1:
+eslint-visitor-keys@^3.3.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz#c22c48f48942d08ca824cc526211ae400478a994"
   integrity sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==
 
-eslint@^8.44.0:
-  version "8.44.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.44.0.tgz#51246e3889b259bbcd1d7d736a0c10add4f0e500"
-  integrity sha512-0wpHoUbDUHgNCyvFB5aXLiQVfK9B0at6gUvzy83k4kAsQ/u769TQDX6iKC+aO4upIHO9WSaA3QoXYQDHbNwf1A==
+eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
+  integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
+
+eslint@8.x:
+  version "8.57.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.57.0.tgz#c786a6fd0e0b68941aaf624596fb987089195668"
+  integrity sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
-    "@eslint-community/regexpp" "^4.4.0"
-    "@eslint/eslintrc" "^2.1.0"
-    "@eslint/js" "8.44.0"
-    "@humanwhocodes/config-array" "^0.11.10"
+    "@eslint-community/regexpp" "^4.6.1"
+    "@eslint/eslintrc" "^2.1.4"
+    "@eslint/js" "8.57.0"
+    "@humanwhocodes/config-array" "^0.11.14"
     "@humanwhocodes/module-importer" "^1.0.1"
     "@nodelib/fs.walk" "^1.2.8"
-    ajv "^6.10.0"
+    "@ungap/structured-clone" "^1.2.0"
+    ajv "^6.12.4"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
     debug "^4.3.2"
     doctrine "^3.0.0"
     escape-string-regexp "^4.0.0"
-    eslint-scope "^7.2.0"
-    eslint-visitor-keys "^3.4.1"
-    espree "^9.6.0"
+    eslint-scope "^7.2.2"
+    eslint-visitor-keys "^3.4.3"
+    espree "^9.6.1"
     esquery "^1.4.2"
     esutils "^2.0.2"
     fast-deep-equal "^3.1.3"
@@ -1142,7 +1241,6 @@ eslint@^8.44.0:
     globals "^13.19.0"
     graphemer "^1.4.0"
     ignore "^5.2.0"
-    import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
     is-glob "^4.0.0"
     is-path-inside "^3.0.3"
@@ -1154,13 +1252,12 @@ eslint@^8.44.0:
     natural-compare "^1.4.0"
     optionator "^0.9.3"
     strip-ansi "^6.0.1"
-    strip-json-comments "^3.1.0"
     text-table "^0.2.0"
 
-espree@^9.6.0:
-  version "9.6.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-9.6.0.tgz#80869754b1c6560f32e3b6929194a3fe07c5b82f"
-  integrity sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==
+espree@^9.6.0, espree@^9.6.1:
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.6.1.tgz#a2a17b8e434690a5432f2f8018ce71d331a48c6f"
+  integrity sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==
   dependencies:
     acorn "^8.9.0"
     acorn-jsx "^5.3.2"
@@ -1283,17 +1380,18 @@ find-up@^5.0.0:
     path-exists "^4.0.0"
 
 flat-cache@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
-  integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.2.0.tgz#2c0c2d5040c99b1632771a9d105725c0115363ee"
+  integrity sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==
   dependencies:
-    flatted "^3.1.0"
+    flatted "^3.2.9"
+    keyv "^4.5.3"
     rimraf "^3.0.2"
 
-flatted@^3.1.0:
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
-  integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
+flatted@^3.2.9:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.1.tgz#21db470729a6734d4997002f439cb308987f567a"
+  integrity sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
 
 follow-redirects@^1.0.0:
   version "1.15.2"
@@ -1396,9 +1494,9 @@ glob@^7.1.1, glob@^7.1.3:
     path-is-absolute "^1.0.0"
 
 globals@^13.19.0:
-  version "13.20.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-13.20.0.tgz#ea276a1e508ffd4f1612888f9d1bad1e2717bf82"
-  integrity sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==
+  version "13.24.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.24.0.tgz#8432a19d78ce0c1e833949c36adb345400bb1171"
+  integrity sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==
   dependencies:
     type-fest "^0.20.2"
 
@@ -1628,7 +1726,12 @@ ignore@^5.1.4, ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
-import-fresh@^3.0.0, import-fresh@^3.2.1:
+ignore@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.1.tgz#5073e554cd42c5b33b394375f538b8593e34d4ef"
+  integrity sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==
+
+import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
   integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
@@ -1880,6 +1983,11 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
+json-buffer@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
+  integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
+
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
@@ -1944,6 +2052,13 @@ jws@^3.2.2:
   dependencies:
     jwa "^1.4.1"
     safe-buffer "^5.0.1"
+
+keyv@^4.5.3:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
+  integrity sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
+  dependencies:
+    json-buffer "3.0.1"
 
 levn@^0.4.1:
   version "0.4.1"
@@ -2095,6 +2210,13 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^9.0.4:
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.4.tgz#8e49c731d1749cbec05050ee5145147b32496a51"
+  integrity sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.8"
@@ -2664,6 +2786,11 @@ semver@^7.3.7:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.6.0:
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.2.tgz#1e3b34759f896e8f14d6134732ce798aeb0c6e13"
+  integrity sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==
+
 semver@~7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
@@ -2830,7 +2957,7 @@ strip-bom@^3.0.0:
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
   integrity sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==
 
-strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
+strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
@@ -2921,6 +3048,11 @@ tree-kill@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
+
+ts-api-utils@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.3.0.tgz#4b490e27129f1e8e686b45cc4ab63714dc60eea1"
+  integrity sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==
 
 ts-node@^9:
   version "9.1.1"


### PR DESCRIPTION
## Description

Massive behavior overhaul and additions. I wish we had tests; anyone reading this that wants to add tests, please get in touch!

You can now turn on/off aggregates,  grouped aggregates, ordering by aggregates and filtering by aggregates on a table-by-table basis; you can also turn on/off individual aggregates (in each of these places) on a per-attribute and per-aggregate-spec basis.

:rotating_light:  This is likely to impact existing schemas, hopefully it doesn't but... it's a lot of changes.

Fixes #60 
Fixes #66 

## Performance impact

Schema build will be slower, runtime performance should be unaffected.

## Security impact

More control over your schema shape is good for security.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~ :sob: 
- [x] I have detailed the new feature in the relevant documentation.
- [ ] ~~I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).~~
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
